### PR TITLE
Update KIC to 2.12.0 and Gateway to 3.4.1.1

### DIFF
--- a/charts/dsb-kong/Chart.yaml
+++ b/charts/dsb-kong/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dsb-kong
-appVersion: "3.1.2"
-version: 3.1.2
+appVersion: "3.1.3"
+version: 3.1.3
 description: Install the Kong, statsd, DSB-specific cluster wide plugins and Kong specific gatekeeper policies
 type: application
 dependencies:

--- a/charts/dsb-kong/values.yaml
+++ b/charts/dsb-kong/values.yaml
@@ -193,10 +193,10 @@ kong:
   # Specify Kong's Docker image and repository details here
   image:
     # repository: kong
-    # tag: "3.3"
+    # tag: "3.4"
     # Kong Enterprise
     repository: kong/kong-gateway
-    tag: "3.3"
+    tag: "3.4.1.1"
     sha: ""
     # Specify a semver version if your image tag is not one (e.g. "nightly")
     effectiveSemver:
@@ -598,7 +598,7 @@ kong:
     installCRDs: false
     image:
       repository: kong/kubernetes-ingress-controller
-      tag: "2.10"
+      tag: "2.12.0"
       sha: ""
       pullPolicy: IfNotPresent
       # Optionally set a semantic version for version-gated features. This can normally


### PR DESCRIPTION
This PR updates the kong gateway to the newest version (3.4.1.1) and the Kong ingress controller to the newest version (2.12.0).

Note - as these changes are only in the values file, the changes will only affect installations if they use the default values