### PR TITLE
Removing default user defined volumes

### DIFF
--- a/charts/dsb-kong/Chart.yaml
+++ b/charts/dsb-kong/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dsb-kong
-appVersion: "3.1.3"
-version: 3.1.3
+appVersion: "3.1.4"
+version: 3.1.4
 description: Install the Kong, statsd, DSB-specific cluster wide plugins and Kong specific gatekeeper policies
 type: application
 dependencies:

--- a/charts/dsb-kong/values.yaml
+++ b/charts/dsb-kong/values.yaml
@@ -105,18 +105,18 @@ kong:
     # Uncomment this setion if not using the secret provider class
     # userDefinedVolumes: {}
     # userDefinedVolumeMounts: {}
-    # And comment this out
-    userDefinedVolumes:
-    - name: secrets-kong-license-inline
-      csi:
-        driver: secrets-store.csi.k8s.io
-        readOnly: true
-        volumeAttributes:
-          secretProviderClass: "kong-license"
-    userDefinedVolumeMounts:
-    - name: secrets-kong-license-inline
-      mountPath: "/mnt/secrets-store"
-      readOnly: true
+    # Uncomment this section if using the secret provider class
+    # userDefinedVolumes:
+    # - name: secrets-kong-license-inline
+    #   csi:
+    #     driver: secrets-store.csi.k8s.io
+    #     readOnly: true
+    #     volumeAttributes:
+    #       secretProviderClass: "kong-license"
+    # userDefinedVolumeMounts:
+    # - name: secrets-kong-license-inline
+    #   mountPath: "/mnt/secrets-store"
+    #   readOnly: true
     test:
       # Enable creation of test resources for use with "helm test"
       enabled: false


### PR DESCRIPTION
The values file no longer includes user defined volumes to prevent surprises when using the chart without a license.